### PR TITLE
Dao0203/issue113

### DIFF
--- a/lib/data/repository/supabase_user_auth_repository.dart
+++ b/lib/data/repository/supabase_user_auth_repository.dart
@@ -21,7 +21,17 @@ final class SupabaseUserAuthRepository implements UserAuthRepository {
 
   @override
   Future<void> signIn(String email, String password) async {
-    await _client.signInWithPassword(email: email, password: password);
+    try {
+      Logger().d('email: $email, password: $password');
+      await _client.signInWithPassword(email: email, password: password);
+    } on AuthException catch (e, stacktrace) {
+      if (e.message == 'Invalid login credentials') {
+        throw const AuthException('invalid_email_or_password');
+      } else {
+        Logger().e(e.message + stacktrace.toString());
+        throw AuthException(e.message);
+      }
+    }
   }
 
   @override
@@ -31,7 +41,11 @@ final class SupabaseUserAuthRepository implements UserAuthRepository {
       await _client.signUp(email: email, password: password);
     } on AuthException catch (e, stacktrace) {
       Logger().e(e.message + stacktrace.toString());
-      rethrow;
+      if (e.message == 'User already registered') {
+        throw const AuthException('user_already_registered');
+      } else {
+        throw AuthException(e.message);
+      }
     }
   }
 }

--- a/lib/ui/view/onboarding/sign_in/sign_in_screen.dart
+++ b/lib/ui/view/onboarding/sign_in/sign_in_screen.dart
@@ -120,6 +120,21 @@ class SignInScreen extends HookConsumerWidget {
                               ),
                               (_) => false,
                             );
+                          }).catchError((e, stacktrace) {
+                            if (e.message == 'invalid_email_or_password') {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                  content: Text('メールアドレスまたはパスワードが間違っています'),
+                                ),
+                              );
+                            } else {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                  content: Text('サインインに失敗しました'),
+                                ),
+                              );
+                            }
+                            Navigator.of(context).pop();
                           });
                         }
                       },

--- a/lib/ui/view/onboarding/sign_up/sign_up_screen.dart
+++ b/lib/ui/view/onboarding/sign_up/sign_up_screen.dart
@@ -147,13 +147,24 @@ class SignUpScreen extends HookConsumerWidget {
                                 ),
                                 (_) => false,
                               );
-                            }).catchError((e) {
+                            }).catchError((e, stackTrace) {
                               Logger().e(e);
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  content: Text(e.toString()),
-                                ),
-                              );
+                              //トーストを表示
+                              if (e.message == 'user_already_registered') {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('既に登録されているメールアドレスです'),
+                                  ),
+                                );
+                              } else {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('サインアップに失敗しました'),
+                                  ),
+                                );
+                              }
+                            }).then((value) {
+                              Navigator.of(context).pop();
                             });
                           }
                         },


### PR DESCRIPTION
close #113 
## やったこと
- repositoryから、Exceptionをスローするようにしている。
  - エラー時のUI構築の容易性：データアクセスのエラーハンドリングをここですることで、UIでキャッチし、UIレイヤのエラーハンドリングのしやすさに貢献
  - データアクセスのテストケースを容易にする：データアクセスのテストケースを容易に変更することが可能。

## 参考
https://zenn.dev/iwaku/articles/2020-12-19-iwaku