### PR TITLE
Dao0203/issue118

### DIFF
--- a/lib/data/repository/supabase_profile_repository.dart
+++ b/lib/data/repository/supabase_profile_repository.dart
@@ -62,7 +62,7 @@ final class SupabaseProfileRepository implements ProfileRepository {
               await supabaseClient.storage
                   .from('avatars')
                   .upload(
-                    '${supabaseClient.auth.currentUser!.id}/avatar.jpeg',
+                    '${supabaseClient.auth.currentUser!.id}/avatar.png',
                     File(filePath),
                     fileOptions: const FileOptions(
                       cacheControl: '3600',
@@ -76,7 +76,7 @@ final class SupabaseProfileRepository implements ProfileRepository {
                   final publicUrl = supabaseClient.storage
                       .from('avatars')
                       .getPublicUrl(
-                          '${supabaseClient.auth.currentUser!.id}/avatar.jpeg');
+                          '${supabaseClient.auth.currentUser!.id}/avatar.png');
                   await supabaseClient
                       .from('profiles')
                       .update({'image_url': publicUrl})

--- a/lib/data/repository/supabase_user_auth_repository.dart
+++ b/lib/data/repository/supabase_user_auth_repository.dart
@@ -52,13 +52,29 @@ final class SupabaseUserAuthRepository implements UserAuthRepository {
 
   @override
   Future<void> delete() async {
-    await Supabase.instance.client.auth.admin
-        .deleteUser(getCurrentUser()!.id)
-        .then((value) {
+    await Supabase.instance.client.rpc('delete_user').then((value) async {
       Logger().d('delete user');
     }).onError((error, stackTrace) {
       Logger().e(error.toString() + stackTrace.toString());
       throw Exception('delete user failed');
+    }).whenComplete(() async {
+      await _client.signOut();
     });
   }
 }
+
+// delete関数がなぜこうなっているか
+// 参考：https://supabase.com/docs/guides/auth/managing-user-data#deleting-users
+//
+// supabase.instance.auth.admin.deleteUser(user.id);はしようできない、かつ
+// クライアント側からは、ユーザーを削除することができない
+// rpcを使用してsupabase側で作成した関数,delete_userを呼び出している
+//
+// この関数は、supabaseのauth.usersテーブルからauth.uidを使用してユーザーを削除する
+// auth.uidはprofiles.idと一致するため、profilesテーブルからprofiles.idを使用してユーザーを削除することもできる
+// すなわち、profilesテーブルのデータが削除されると、全ての関連するデータが削除される
+// 
+// delete関数の中でsignOut関数を呼び出しているか
+// これは、delete関数を呼び出すと、ユーザーが削除されるが、
+// クライアント側に削除されたはずのユーザーの情報が残ってしまうため、
+// クライアント側のユーザー情報を削除するためにsignOut関数を呼び出している

--- a/lib/data/repository/supabase_user_auth_repository.dart
+++ b/lib/data/repository/supabase_user_auth_repository.dart
@@ -54,11 +54,10 @@ final class SupabaseUserAuthRepository implements UserAuthRepository {
   Future<void> delete() async {
     await Supabase.instance.client.rpc('delete_user').then((value) async {
       Logger().d('delete user');
+      await _client.signOut();
     }).onError((error, stackTrace) {
       Logger().e(error.toString() + stackTrace.toString());
       throw Exception('delete user failed');
-    }).whenComplete(() async {
-      await _client.signOut();
     });
   }
 }

--- a/lib/data/repository/supabase_user_auth_repository.dart
+++ b/lib/data/repository/supabase_user_auth_repository.dart
@@ -49,4 +49,16 @@ final class SupabaseUserAuthRepository implements UserAuthRepository {
       }
     }
   }
+
+  @override
+  Future<void> delete() async {
+    await Supabase.instance.client.auth.admin
+        .deleteUser(getCurrentUser()!.id)
+        .then((value) {
+      Logger().d('delete user');
+    }).onError((error, stackTrace) {
+      Logger().e(error.toString() + stackTrace.toString());
+      throw Exception('delete user failed');
+    });
+  }
 }

--- a/lib/data/repository/user_auth_repository.dart
+++ b/lib/data/repository/user_auth_repository.dart
@@ -6,4 +6,5 @@ abstract interface class UserAuthRepository {
   Future<void> signUp(String email, String password);
   Future<void> signIn(String email, String password);
   Future<void> signOut();
+  Future<void> delete();
 }

--- a/lib/ui/view/profile/profile_screen.dart
+++ b/lib/ui/view/profile/profile_screen.dart
@@ -361,20 +361,23 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
                               : const SizedBox(),
                           const SizedBox(width: 8),
                           //学年
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 16),
-                            child: Text(
-                              data.profile.grade.toString(),
-                              style: TextStyle(
-                                fontSize: 16,
-                                //すこし透明にする
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSurface
-                                    .withOpacity(0.7),
-                              ),
-                            ),
-                          ),
+                          data.profile.grade != null
+                              ? Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 16),
+                                  child: Text(
+                                    data.profile.grade!,
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      //すこし透明にする
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurface
+                                          .withOpacity(0.7),
+                                    ),
+                                  ),
+                                )
+                              : const SizedBox(),
                           //自己紹介
                           const SizedBox(height: 16),
                           Padding(

--- a/lib/ui/view/profile/profile_screen.dart
+++ b/lib/ui/view/profile/profile_screen.dart
@@ -6,7 +6,7 @@ import 'package:share_study_app/data/repository/di/repository_providers.dart';
 import 'package:share_study_app/ui/state/activity_profile_state.dart';
 import 'package:share_study_app/ui/state/is_following_state.dart';
 import 'package:share_study_app/ui/view/follow/follow_screen.dart';
-import 'package:share_study_app/ui/view/profile/profile_update_screen.dart';
+import 'package:share_study_app/ui/view/profile/profile_setting_screen.dart';
 import 'package:share_study_app/ui/view/profile/resolved_question_tab.dart';
 import 'package:share_study_app/ui/view/profile/quetion_tab.dart';
 
@@ -73,7 +73,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
                                           Navigator.of(context).push(
                                             MaterialPageRoute(
                                               builder: (_) {
-                                                return ProfileUpdateScreen(
+                                                return ProfileSettingScreen(
                                                     profile: data.profile);
                                               },
                                               fullscreenDialog: true,

--- a/lib/ui/view/profile/profile_setting_screen.dart
+++ b/lib/ui/view/profile/profile_setting_screen.dart
@@ -12,8 +12,8 @@ import 'package:share_study_app/ui/state/my_profile_state.dart';
 import 'package:share_study_app/ui/view/onboarding/sign_in/sign_in_screen.dart';
 import 'package:share_study_app/util/image_picker_app.dart';
 
-class ProfileUpdateScreen extends HookConsumerWidget {
-  ProfileUpdateScreen({super.key, required this.profile});
+class ProfileSettingScreen extends HookConsumerWidget {
+  ProfileSettingScreen({super.key, required this.profile});
   final Profile profile;
   final gradeList = [
     '学士1年',
@@ -103,8 +103,13 @@ class ProfileUpdateScreen extends HookConsumerWidget {
                         //TODO: エラーの種類で分岐したい、またカスタムスナックバーを他のブランチで作成している予定なので、
                         //終わり次第ここに実装する
                         ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(e.toString()),
+                          CustomSnackBar.createError(
+                            context: context,
+                            text: '保存に失敗しました。',
+                            icon: Icon(
+                              Icons.error,
+                              color: Theme.of(context).colorScheme.error,
+                            ),
                           ),
                         );
                       },

--- a/lib/ui/view/profile/profile_setting_screen.dart
+++ b/lib/ui/view/profile/profile_setting_screen.dart
@@ -376,7 +376,7 @@ class ProfileSettingScreen extends HookConsumerWidget {
                                           .showSnackBar(
                                         CustomSnackBar.create(
                                           context: context,
-                                          text: '削除しました。',
+                                          text: 'ユーザーを削除しました',
                                           icon: Icon(
                                             Icons.check,
                                             color: Theme.of(context)

--- a/lib/ui/view/profile/profile_setting_screen.dart
+++ b/lib/ui/view/profile/profile_setting_screen.dart
@@ -100,8 +100,6 @@ class ProfileSettingScreen extends HookConsumerWidget {
                     ).catchError(
                       (e, s) {
                         isLoading.value = false;
-                        //TODO: エラーの種類で分岐したい、またカスタムスナックバーを他のブランチで作成している予定なので、
-                        //終わり次第ここに実装する
                         ScaffoldMessenger.of(context).showSnackBar(
                           CustomSnackBar.createError(
                             context: context,
@@ -311,17 +309,46 @@ class ProfileSettingScreen extends HookConsumerWidget {
                         context: context,
                         builder: (context) {
                           return AlertDialog(
-                            title: const Text('ユーザ削除'),
-                            content: const Text('本当に削除しますか？'),
+                            title: const Text('ユーザの削除'),
+                            content: Text(
+                              '削除したユーザは復元できず、関連したデータ全てが削除されます。',
+                              //少しだけ透明にする
+                              style: TextStyle(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onBackground
+                                    .withOpacity(0.5),
+                              ),
+                            ),
                             actions: [
                               TextButton(
                                 onPressed: () {
                                   Navigator.of(context).pop();
                                 },
-                                child: const Text('キャンセル'),
+                                child: Text(
+                                  'キャンセル',
+                                  style: TextStyle(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onBackground,
+                                  ),
+                                ),
                               ),
                               TextButton(
                                 onPressed: () {
+                                  showGeneralDialog(
+                                    barrierDismissible: false,
+                                    context: context,
+                                    pageBuilder: (context, animation,
+                                        secondaryAnimation) {
+                                      return WillPopScope(
+                                        onWillPop: () async => false,
+                                        child: const Center(
+                                          child: CircularProgressIndicator(),
+                                        ),
+                                      );
+                                    },
+                                  );
                                   ref
                                       .read(userAuthRepositoryProvider)
                                       .delete()
@@ -331,7 +358,7 @@ class ProfileSettingScreen extends HookConsumerWidget {
                                           .showSnackBar(
                                         CustomSnackBar.createError(
                                           context: context,
-                                          text: '削除に失敗しました。',
+                                          text: '削除に失敗しました',
                                           icon: Icon(
                                             Icons.error,
                                             color: Theme.of(context)
@@ -340,26 +367,47 @@ class ProfileSettingScreen extends HookConsumerWidget {
                                           ),
                                         ),
                                       );
+                                      Navigator.of(context).pop();
+                                    },
+                                  ).then(
+                                    (value) {
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(
+                                        CustomSnackBar.create(
+                                          context: context,
+                                          text: '削除しました。',
+                                          icon: Icon(
+                                            Icons.check,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .onSurface,
+                                          ),
+                                        ),
+                                      );
+                                      Navigator.of(context).push(
+                                        MaterialPageRoute(
+                                          builder: (context) =>
+                                              const SignInScreen(),
+                                          maintainState: false,
+                                        ),
+                                      );
                                     },
                                   );
-                                  Navigator.of(context).push(
-                                    MaterialPageRoute(
-                                      builder: (context) {
-                                        return const SignInScreen();
-                                      },
-                                      maintainState: false,
-                                    ),
-                                  );
                                 },
-                                child: const Text('ユーザの削除'),
+                                child: const Text(
+                                  '削除',
+                                  style: TextStyle(
+                                    color: Colors.red,
+                                  ),
+                                ),
                               ),
                             ],
                           );
                         },
                       );
                     },
-                    icon: Icon(Icons.delete),
-                    label: Text('ユーザ削除'),
+                    icon: const Icon(Icons.delete),
+                    label: const Text('削除'),
                   ),
                 ],
               ),

--- a/lib/ui/view/profile/profile_setting_screen.dart
+++ b/lib/ui/view/profile/profile_setting_screen.dart
@@ -302,6 +302,7 @@ class ProfileSettingScreen extends HookConsumerWidget {
                     maxLength: 100,
                     maxLines: 3,
                   ),
+                  const SizedBox(height: 20),
                   //ユーザ削除のボタン
                   ElevatedButton.icon(
                     onPressed: () {
@@ -406,9 +407,18 @@ class ProfileSettingScreen extends HookConsumerWidget {
                         },
                       );
                     },
-                    icon: const Icon(Icons.delete),
-                    label: const Text('削除'),
+                    icon: const Icon(
+                      Icons.delete,
+                      color: Colors.red,
+                    ),
+                    label: const Text(
+                      'ユーザを削除する',
+                      style: TextStyle(
+                        color: Colors.red,
+                      ),
+                    ),
                   ),
+                  const SizedBox(height: 20),
                 ],
               ),
             ),

--- a/lib/ui/view/profile/profile_update_screen.dart
+++ b/lib/ui/view/profile/profile_update_screen.dart
@@ -6,8 +6,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:share_study_app/data/domain/profile.dart';
 import 'package:share_study_app/data/repository/di/repository_providers.dart';
+import 'package:share_study_app/ui/components/custom_snack_bar.dart';
 import 'package:share_study_app/ui/state/activity_profile_state.dart';
 import 'package:share_study_app/ui/state/my_profile_state.dart';
+import 'package:share_study_app/ui/view/onboarding/sign_in/sign_in_screen.dart';
 import 'package:share_study_app/util/image_picker_app.dart';
 
 class ProfileUpdateScreen extends HookConsumerWidget {
@@ -296,6 +298,63 @@ class ProfileUpdateScreen extends HookConsumerWidget {
                     ),
                     maxLength: 100,
                     maxLines: 3,
+                  ),
+                  //ユーザ削除のボタン
+                  ElevatedButton.icon(
+                    onPressed: () {
+                      showDialog(
+                        context: context,
+                        builder: (context) {
+                          return AlertDialog(
+                            title: const Text('ユーザ削除'),
+                            content: const Text('本当に削除しますか？'),
+                            actions: [
+                              TextButton(
+                                onPressed: () {
+                                  Navigator.of(context).pop();
+                                },
+                                child: const Text('キャンセル'),
+                              ),
+                              TextButton(
+                                onPressed: () {
+                                  ref
+                                      .read(userAuthRepositoryProvider)
+                                      .delete()
+                                      .catchError(
+                                    (e, s) {
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(
+                                        CustomSnackBar.createError(
+                                          context: context,
+                                          text: '削除に失敗しました。',
+                                          icon: Icon(
+                                            Icons.error,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .error,
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  );
+                                  Navigator.of(context).push(
+                                    MaterialPageRoute(
+                                      builder: (context) {
+                                        return const SignInScreen();
+                                      },
+                                      maintainState: false,
+                                    ),
+                                  );
+                                },
+                                child: const Text('ユーザの削除'),
+                              ),
+                            ],
+                          );
+                        },
+                      );
+                    },
+                    icon: Icon(Icons.delete),
+                    label: Text('ユーザ削除'),
                   ),
                 ],
               ),


### PR DESCRIPTION
## 目的
close #118 
ユーザ情報削除の実装をしないとapp storeにrejectされてしまうため、追加する必要がある。
## やったこと
- profile setting screenの中に削除ボタンを設置
- delete関数の実装
- delete時のエラーハンドリング
<img src='https://github.com/dao0203/share_study_app/assets/111327327/ea8d9498-1b45-4d69-b76f-c5d9d10cf619' width='200'>
<img src='https://github.com/dao0203/share_study_app/assets/111327327/8c81ecc4-da88-4211-aad8-873873d87a68' width='200'>
